### PR TITLE
Fix duplicate application of self.db_select

### DIFF
--- a/qm9star_query/dataset/base_dataset.py
+++ b/qm9star_query/dataset/base_dataset.py
@@ -146,7 +146,7 @@ class BaseQM9starDataset(InMemoryDataset):
             SnapshotOut.model_validate(snapshot).model_dump()
             for snapshot in tqdm(
                 self.session.exec(
-                    self.db_select(select(Snapshot))
+                    select(Snapshot)
                     .where(col(Snapshot.id).in_(snapshot_ids))
                     .order_by(Snapshot.id)
                 ).all(),


### PR DESCRIPTION
Select snapshots based on selected indices. Thereby, avoid applying the selection function on the indices again. This might work in many cases, but fails e.g. when applying an `offset`.